### PR TITLE
Fix infinity booster not working anymore

### DIFF
--- a/src/main/java/net/p455w0rd/wirelesscraftingterminal/common/container/ContainerWirelessCraftingTerminal.java
+++ b/src/main/java/net/p455w0rd/wirelesscraftingterminal/common/container/ContainerWirelessCraftingTerminal.java
@@ -822,16 +822,14 @@ public class ContainerWirelessCraftingTerminal extends AEBaseContainer
     }
 
     public boolean isBoosterInstalled() {
-        Slot slot = getSlotFromInventory(this.boosterInventory, BOOSTER_INDEX);
+        Slot slot = getSlotFromInventory(this.boosterInventory, 0);
         if (slot == null) {
             return false;
         }
-        boolean hasStack =
-                getSlotFromInventory(this.boosterInventory, BOOSTER_INDEX).getHasStack();
+        boolean hasStack = getSlotFromInventory(this.boosterInventory, 0).getHasStack();
         if (hasStack) {
-            Item boosterSlotContents = getSlotFromInventory(this.boosterInventory, BOOSTER_INDEX)
-                    .getStack()
-                    .getItem();
+            Item boosterSlotContents =
+                    getSlotFromInventory(this.boosterInventory, 0).getStack().getItem();
             return boosterSlotContents instanceof ItemInfinityBooster;
         }
         return false;


### PR DESCRIPTION
The isBoosterInstalled() function was using the wrong slot index after the shift to fix it getting removed from the WCT easily

Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11418>