### PR TITLE
Update ItemMagnet.java

### DIFF
--- a/src/main/java/net/p455w0rd/wirelesscraftingterminal/items/ItemMagnet.java
+++ b/src/main/java/net/p455w0rd/wirelesscraftingterminal/items/ItemMagnet.java
@@ -192,13 +192,13 @@ public class ItemMagnet extends Item {
 
     @Override
     public ItemStack onItemRightClick(ItemStack item, World world, EntityPlayer player) {
-        if (!world.isRemote) {
-            if (player.isSneaking()) {
-                switchMagnetMode(item, player);
-            } else {
-                if (!RandomUtils.isMagnetInitialized(item)) {
-                    NetworkHandler.instance.sendToServer(new PacketMagnetFilter(0, true));
-                }
+        if (player.isSneaking() && !world.isRemote) {
+            switchMagnetMode(item, player);
+        } else {
+            if (!RandomUtils.isMagnetInitialized(item) && world.isRemote) {
+                NetworkHandler.instance.sendToServer(new PacketMagnetFilter(0, true));
+            }
+            if (!world.isRemote) {
                 int x = (int) player.posX;
                 int y = (int) player.posY;
                 int z = (int) player.posZ;


### PR DESCRIPTION
Ordnungsgemäße Trennung in Server und Client. Sonst geht die Logik verloren, wenn "!world.isRemote" ein Paket an den Server sendet... Es bringt den Server zum Absturz.

-----
Proper separation for server and client. Otherwise the logic is lost when "!world.isRemote" sends a packet to the server... it crashes the server.